### PR TITLE
Package eugener_test_ocaml.0.1.0

### DIFF
--- a/packages/eugener_test_ocaml/eugener_test_ocaml.0.1.0/opam
+++ b/packages/eugener_test_ocaml/eugener_test_ocaml.0.1.0/opam
@@ -1,0 +1,37 @@
+opam-version: "2.0"
+synopsis: "Test project. don't download"
+description:
+  "test project. don't downloadtest project. don't downloadtest project. don't downloadtest project. don't download"
+maintainer: "your-email@gmail.com"
+authors: "Some name"
+license: "MIT"
+homepage: "hhttps://github.com/pypi/warehouse"
+bug-reports: "https://github.com/pypi/warehouse/issues"
+depends: [
+  "ocaml"
+  "dune" {>= "3.16"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/pypi/warehouse.git"
+url {
+  src:
+    "https://github.com/eugenebmx/eugener-test-ocaml/archive/refs/tags/v0.1.0.tar.gz"
+  checksum: [
+    "md5=06887117d68769028e33ee7bb453e0e7"
+    "sha512=5472b5b8dedfb20dd6d02ad55dcb7e14c463d765e9dc207ab84a123e8007dfe08905d73898e38c8fca4f8bc38a9c61e825f3ccd78aab0906981c792e0cee314e"
+  ]
+}


### PR DESCRIPTION
### `eugener_test_ocaml.0.1.0`
Test project. don't download
test project. don't downloadtest project. don't downloadtest project. don't downloadtest project. don't download



---
* Homepage: hhttps://github.com/pypi/warehouse
* Source repo: git+https://github.com/pypi/warehouse.git
* Bug tracker: https://github.com/pypi/warehouse/issues

---
:camel: Pull-request generated by opam-publish v2.4.0